### PR TITLE
yapf 0.43.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,0 @@
-aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "yapf" %}
-{% set version = "0.40.2" %}
-{% set sha256 = "8e0825803c488aa2cb118ed277a18d4617984608e75d10d5bffa5e24734eb022" %}
+{% set version = "0.43.0" %}
 
 package:
   name: {{ name }}
@@ -8,27 +7,26 @@ package:
 
 source:
   url: https://github.com/google/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 1d8ca9d7e1fc429c496e0a046e509e437d5ae766487b0394c45fc1fdf253b5d4
 
 build:
+  number: 0
   entry_points:
     - yapf = yapf:run_main
     - yapf-diff = yapf_third_party.yapf_diff.yapf_diff:main
-  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skipt: true # [py<37]
 
 requirements:
   host:
-    - python
     - pip
-    - setuptools
+    - python
     - wheel
+    - setuptools >=58.5.0
   run:
     - python
-    - importlib-metadata >=6.6.0
     - platformdirs >=3.5.1
-    - tomli >=2.0.1
+    - tomli >=2.0.1  # [py<311]
 
 test:
   source_files:


### PR DESCRIPTION
yapf 0.43.0 

**Destination channel:** Defaults

### Links

- [PKG-10262]
- dev_url:        https://github.com/google/yapf/tree/v0.43.0
- conda_forge:    https://github.com/conda-forge/yapf-feedstock
- pypi:           https://pypi.org/project/yapf/0.43.0
- pypi inspector: https://inspector.pypi.io/project/yapf/0.43.0

### Explanation of changes:

- new version number


[PKG-10262]: https://anaconda.atlassian.net/browse/PKG-10262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ